### PR TITLE
suggested change, but test fails

### DIFF
--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/FromRecord.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/FromRecord.scala
@@ -1,18 +1,18 @@
 package com.sksamuel.avro4s
 
 import org.apache.avro.Schema
-import org.apache.avro.generic.GenericRecord
+import org.apache.avro.generic.IndexedRecord
 
 /**
   * Converts from an Avro GenericRecord into instances of T.
   */
 trait FromRecord[T] extends Serializable {
-  def from(record: GenericRecord): T
+  def from(record: IndexedRecord): T
 }
 
 object FromRecord {
   def apply[T: Decoder : SchemaFor]: FromRecord[T] = apply(AvroSchema[T])
   def apply[T: Decoder](schema: Schema): FromRecord[T] = new FromRecord[T] {
-    override def from(record: GenericRecord): T = implicitly[Decoder[T]].decode(record, record.getSchema)
+    override def from(record: IndexedRecord): T = implicitly[Decoder[T]].decode(record, record.getSchema)
   }
 }

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/RecordFormat.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/RecordFormat.scala
@@ -1,7 +1,7 @@
 package com.sksamuel.avro4s
 
 import org.apache.avro.Schema
-import org.apache.avro.generic.GenericRecord
+import org.apache.avro.generic.{GenericRecord, IndexedRecord}
 
 /**
   * Brings together [[ToRecord]] and [[FromRecord]] in a single interface.
@@ -19,7 +19,7 @@ object RecordFormat {
   def apply[T : Encoder : Decoder](schema: Schema): RecordFormat[T] = new RecordFormat[T] {
     private val fromRecord = FromRecord[T](schema)
     private val toRecord = ToRecord[T](schema)
-    override def from(record: GenericRecord): T = fromRecord.from(record)
+    override def from(record: IndexedRecord): T = fromRecord.from(record)
     override def to(t: T): Record = toRecord.to(t)
   }
 }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/github/Github284.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/github/Github284.scala
@@ -1,0 +1,58 @@
+package com.sksamuel.avro4s.github
+
+import com.sksamuel.avro4s.{Record, RecordFormat}
+import org.scalatest.{Matchers, WordSpec}
+import org.apache.avro.specific.SpecificRecordBase
+import org.apache.avro.{AvroRuntimeException, Schema}
+
+case class Street(var name: String) extends SpecificRecordBase {
+  def this() = this("")
+
+  override def get(i: Int): AnyRef = i match {
+    case 0 => name
+    case _ => throw new AvroRuntimeException("Bad index")
+  }
+
+  override def put(index: Int, value: scala.Any): Unit =
+    index match {
+      case 0 =>
+        value.asInstanceOf[String]
+      case _ =>
+        throw new AvroRuntimeException("Bad index")
+    }
+
+  override def getSchema: Schema = Street.SCHEMA$
+}
+
+object Street {
+  val SCHEMA$ =
+    (new Schema.Parser).parse("""
+                                |{
+                                | "type": "record",
+                                | "namespace": "com.sksamuel.avro4s.github",
+                                | "name": "Street",
+                                | "fields": [
+                                |     {"name": "name", "type": "string"}
+                                | ]
+                                |}
+                              """.stripMargin)
+}
+
+final class Github284 extends WordSpec with Matchers {
+  "SchemaFor" should {
+    "convert case class to a Record and convert it back to original case class" in {
+
+      val street: Street = Street(name = "street name")
+
+      val streetAsRecord: Record = RecordFormat[Street].to(street)
+
+      val decodedStreet: Street = RecordFormat[Street].from(streetAsRecord)
+
+      streetAsRecord shouldBe a [Record]
+
+      decodedStreet shouldBe a [Street]
+
+      decodedStreet shouldBe street
+    }
+  }
+}


### PR DESCRIPTION
made the change as suggested, however, my added tests failed, which confirm my expectation that, avro4s uses GenericDatum to ser/des both GenericRecord and SpecificRecord